### PR TITLE
Add PowerShell script for compiling DevTools

### DIFF
--- a/makedevtools.ps1
+++ b/makedevtools.ps1
@@ -1,0 +1,1 @@
+..\..\bin\php\php.exe ./src/DevTools/ConsoleScript.php --make . --relative . --out ../DevTools.phar


### PR DESCRIPTION
DevTools must be properly be placed in /plugins. Double click the script builds devtools and puts it into /plugins. "requires" to be run in a fully set up PM enviroment