### PR TITLE
New command: /makeplugin *

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@
 - Restart the server. The plugin will be loaded
 
 ## Usage
-* _/makeplugin <pluginName>_: Creates a Phar plugin archive for its distribution
+* _/makeplugin \<pluginName\>_: Creates a Phar plugin archive for its distribution
+* _/makeplugin *_: Creates Phar plugin archives for all loaded plugins
 * _/makeserver_: Creates a PocketMine-MP Phar archive
-* _/checkperm <node> [playerName]_: Checks a permission node
+* _/checkperm \<node\> [playerName]_: Checks a permission node
 
 ## Using ConsoleScript to build a DevTools phar from source code
 Contrary to popular assumption, this is very simple. Assuming you have a php executable in your PATH variable, cd into the DevTools directory (the folder where plugin.yml is located) and simply run the following:

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: DevTools
 main: DevTools\DevTools
 version: 1.12.4
-api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9]
+api: [3.0.0-ALPHA7, 3.0.0-ALPHA8]
 load: STARTUP
 author: PocketMine Team
 description: Helps develop and distribute PocketMine-MP plugins

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: DevTools
 main: DevTools\DevTools
 version: 1.12.4
-api: [3.0.0-ALPHA7, 3.0.0-ALPHA8]
+api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9]
 load: STARTUP
 author: PocketMine Team
 description: Helps develop and distribute PocketMine-MP plugins

--- a/src/DevTools/DevTools.php
+++ b/src/DevTools/DevTools.php
@@ -75,7 +75,8 @@ class DevTools extends PluginBase implements CommandExecutor{
 					}
 					return true;
 				}else{
-					return $this->makePluginCommand($sender, $command, $label, $args);
+					$this->makePluginCommand($sender, $command, $label, $args);
+					return true;
 				}
 			case "makeserver":
 				return $this->makeServerCommand($sender, $command, $label, $args);

--- a/src/DevTools/DevTools.php
+++ b/src/DevTools/DevTools.php
@@ -58,8 +58,13 @@ class DevTools extends PluginBase implements CommandExecutor{
 				}elseif(isset($args[0]) and $args[0] === "*"){
 					$plugins = $this->getServer()->getPluginManager()->getPlugins();
 					$succeeded = $failed = [];
+					$skipped = 0;
 					foreach($plugins as $plugin){
-						if(($plugin->getPluginLoader() instanceof FolderPluginLoader) && $this->makePluginCommand($sender, $command, $label, [$plugin->getName()])){
+						if(!$plugin->getPluginLoader() instanceof FolderPluginLoader){
+							$skipped++;
+							continue;
+						}
+						if($this->makePluginCommand($sender, $command, $label, [$plugin->getName()])){
 							$succeeded[] = $plugin->getName();
 						}else{
 							$failed[] = $plugin->getName();
@@ -70,7 +75,7 @@ class DevTools extends PluginBase implements CommandExecutor{
 							. (count($failed) === 1 ? "" : "s") . " failed to build: " . implode(", ", $failed));
 					}
 					if(count($succeeded) > 0){
-						$sender->sendMessage(TextFormat::GREEN . count($succeeded) . "/" . count($plugins) . " plugin"
+						$sender->sendMessage(TextFormat::GREEN . count($succeeded) . "/" . (count($plugins) - $skipped) . " plugin"
 							. (count($plugins) === 1 ? "" : "s") . " successfully built: " . implode(", ", $succeeded));
 					}
 					return true;

--- a/src/DevTools/DevTools.php
+++ b/src/DevTools/DevTools.php
@@ -76,7 +76,7 @@ class DevTools extends PluginBase implements CommandExecutor{
 					}
 					if(count($succeeded) > 0){
 						$sender->sendMessage(TextFormat::GREEN . count($succeeded) . "/" . (count($plugins) - $skipped) . " plugin"
-							. (count($plugins) === 1 ? "" : "s") . " successfully built: " . implode(", ", $succeeded));
+							. ((count($plugins) - $skipped) === 1 ? "" : "s") . " successfully built: " . implode(", ", $succeeded));
 					}
 					return true;
 				}else{

--- a/src/DevTools/DevTools.php
+++ b/src/DevTools/DevTools.php
@@ -59,7 +59,7 @@ class DevTools extends PluginBase implements CommandExecutor{
 					$plugins = $this->getServer()->getPluginManager()->getPlugins();
 					$succeeded = $failed = [];
 					foreach($plugins as $plugin){
-						if($this->makePluginCommand($sender, $command, $label, [$plugin->getName()])){
+						if(($plugin->getPluginLoader() instanceof FolderPluginLoader) && $this->makePluginCommand($sender, $command, $label, [$plugin->getName()])){
 							$succeeded[] = $plugin->getName();
 						}else{
 							$failed[] = $plugin->getName();


### PR DESCRIPTION
This PR adds the command `/makeplugin *` to make a distributable phar archive for every plugin loaded from source. Displays a report when finished detailing the results