### PR TITLE
ConsoleScript: Allow to include single files by passing them via --make

### DIFF
--- a/src/DevTools/ConsoleScript.php
+++ b/src/DevTools/ConsoleScript.php
@@ -55,7 +55,8 @@ function preg_quote_array(array $strings, string $delim = null) : array{
 function buildPhar(string $pharPath, string $basePath, array $includedPaths, array $metadata, string $stub, int $signatureAlgo = \Phar::SHA1, ?int $compression = null){
 	$basePath = rtrim(str_replace("/", DIRECTORY_SEPARATOR, $basePath), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 	$includedPaths = array_map(function($path) : string{
-		return rtrim(str_replace("/", DIRECTORY_SEPARATOR, $path), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+		$path = rtrim(str_replace("/", DIRECTORY_SEPARATOR, $path), DIRECTORY_SEPARATOR);
+		return is_dir($path) ? $path . DIRECTORY_SEPARATOR : $path;
 	}, $includedPaths);
 	if(file_exists($pharPath)){
 		yield "Phar file already exists, overwriting...";


### PR DESCRIPTION
## Introduction
Currently, a trailing slash is added at the end of every path passed to --make, regardless of whether at the given path there is a directory or a file. This is preventing the user from adding single files to the build process because the trailing slash prevents the file from being added to the PHAR file.

## Changes
This PR makes so that, before adding the trailing slash to each path, the script checks whether or not at the given path there is a file or a directory and adds the trailing slash only in the second case.

### Relevant issues
This PR does not yet allow the user to add files whose name begins with a dot because those are being excluded from the start here: https://github.com/pmmp/DevTools/blob/963981d1975f603bcbcb3f52c9f69ae3046f4949/src/DevTools/ConsoleScript.php#L84-L93
I personally don't know how to fix this because of lack of experience with RegEx expressions.

## Follow-up
Allow users to include dotfiles in the PHAR by overriding the exclusion list if they are being passed using --make

## Tests
### Before
```
../../bin/php7/bin/php ../DevTools/src/DevTools/ConsoleScript.php --make "src,resources,plugin.yml,.poggit.yml" --relative . --out "build/target/out.phar"


Phar file already exists, overwriting...
Adding files...
Added 6 files
Done in 0.053s
```

### After
```
../../bin/php7/bin/php ../DevTools/src/DevTools/ConsoleScript.php --make "src,resources,plugin.yml,.poggit.yml" --relative . --out "build/target/out.phar"


Phar file already exists, overwriting...
Adding files...
Added 7 files
Done in 0.082s
```
As it can be seen, it says "7 files" instead of 8 because of .poggit.yml being ignored as it's a dotfile.